### PR TITLE
Update urls to re_path for Django 4

### DIFF
--- a/static_sitemaps/urls.py
+++ b/static_sitemaps/urls.py
@@ -3,7 +3,7 @@ Created on 24.10.2011
 
 @author: xaralis
 '''
-from django.conf.urls import url
+from django.conf.urls import re_path
 
 from .views import index_view, page_view
 
@@ -11,8 +11,8 @@ from .views import index_view, page_view
 app_name = "static_sitemaps"
 
 urlpatterns = [
-    url(r'^sitemap_index.xml$', index_view, name='static_sitemaps_index'),
+    re_path(r"^sitemap_index.xml$", index_view, name="static_sitemaps_index"),
     # This is mainly for testing, though could rewrite the above index file with links like below, if so inclined,
     # Using xml parser and loading the index from S3 (like with passthru setting).
-    url(r'^sitemap_(?P<filename>.*)$', page_view, name='static_sitemaps_page'),
+    re_path(r"^sitemap_(?P<filename>.*)$", page_view, name="static_sitemaps_page"),
 ]


### PR DESCRIPTION
Migrate `url` -> `re_path`. Likely to be more changes required.