### PR TITLE
Fix re_path import path

### DIFF
--- a/static_sitemaps/urls.py
+++ b/static_sitemaps/urls.py
@@ -3,7 +3,7 @@ Created on 24.10.2011
 
 @author: xaralis
 '''
-from django.conf.urls import re_path
+from django.urls import re_path
 
 from .views import index_view, page_view
 


### PR DESCRIPTION
Failed to correctly update the import path for Django 4 when updating `url` to `re_path`.